### PR TITLE
🛠️ Refactor: Extract Git logic to GitManager class

### DIFF
--- a/cloud_savegame/git.py
+++ b/cloud_savegame/git.py
@@ -1,0 +1,43 @@
+import logging
+import subprocess
+from shutil import which
+
+logger = logging.getLogger(__name__)
+
+
+class GitManager:
+    def __init__(self, enabled: bool):
+        self.binary = which("git")
+        if enabled and self.binary is None:
+            raise AssertionError("git required but not available")
+        self.enabled = enabled
+
+    def run(self, *params, always_show=False) -> None:
+        """
+        Execute a git command with the provided parameters.
+
+        Args:
+            *params: Command line arguments to pass to git.
+            always_show: Unused parameter (legacy).
+        """
+        if not self.enabled or self.binary is None:
+            return
+
+        logger.info("git: %s", " ".join(f"'{p}'" for p in params))
+        subprocess.call([self.binary, *params])
+
+    def is_dirty(self) -> bool:
+        """
+        Check if the current git repository has uncommitted changes.
+
+        Returns:
+            bool: True if `git status -s` returns any output (indicating dirtiness),
+            False otherwise.
+        """
+        if not self.enabled or self.binary is None:
+            return False
+
+        status_result = subprocess.run(
+            [self.binary, "status", "-s"], capture_output=True, text=True
+        )
+        return bool(status_result.stdout)

--- a/tests/test_git_refactor.py
+++ b/tests/test_git_refactor.py
@@ -1,0 +1,45 @@
+import shutil
+from unittest.mock import MagicMock, patch
+
+from cloud_savegame.git import GitManager
+
+
+def test_git_manager_init():
+    # If git is available
+    if shutil.which("git"):
+        mgr = GitManager(enabled=True)
+        assert mgr.enabled
+        assert mgr.binary is not None
+
+        mgr_disabled = GitManager(enabled=False)
+        assert not mgr_disabled.enabled
+    else:
+        # If git is not available, enabled=True should raise
+        try:
+            GitManager(enabled=True)
+            assert False, "Should raise AssertionError"
+        except AssertionError:
+            pass
+
+
+@patch("cloud_savegame.git.subprocess")
+def test_git_manager_run(mock_subprocess):
+    mgr = GitManager(enabled=True)
+    mgr.binary = "/usr/bin/git"  # Force a path for testing
+
+    mgr.run("status")
+    mock_subprocess.call.assert_called_with(["/usr/bin/git", "status"])
+
+
+@patch("cloud_savegame.git.subprocess")
+def test_git_manager_is_dirty(mock_subprocess):
+    mgr = GitManager(enabled=True)
+    mgr.binary = "/usr/bin/git"
+
+    # Mock return value for clean repo
+    mock_subprocess.run.return_value = MagicMock(stdout="")
+    assert mgr.is_dirty() is False
+
+    # Mock return value for dirty repo
+    mock_subprocess.run.return_value = MagicMock(stdout="M file.txt")
+    assert mgr.is_dirty() is True


### PR DESCRIPTION
Extracts Git logic to `GitManager` class to improve modularity and adhere to SRP.

## Changes
- Move `git` and `git_is_repo_dirty` logic to `cloud_savegame/git.py`.
- Create `GitManager` class to handle git binary resolution and execution.
- Update `cloud_savegame/__init__.py` to use `GitManager`.
- Add unit tests for `GitManager`.

## Justification
Following the Single Responsibility Principle (SRP) as described by Martin (Clean Code), this refactoring separates the concern of Version Control interaction from the main application logic. This reduces the cognitive load when reading `__init__.py` and makes the Git logic easier to test in isolation.

---
*PR created automatically by Jules for task [14134469013112534408](https://jules.google.com/task/14134469013112534408) started by @lucasew*