### PR TITLE
🛠️ Refactor: Extract config helpers to config_utils.py

### DIFF
--- a/cloud_savegame/__init__.py
+++ b/cloud_savegame/__init__.py
@@ -29,7 +29,10 @@ from pathlib import Path
 from pprint import pformat
 from shutil import SameFileError, copyfile, which
 from time import time
-from typing import Iterator, List, Optional, Set, Tuple
+from typing import Iterator, Optional, Set, Tuple
+
+from cloud_savegame.config_utils import get_bool, get_paths, get_str
+from cloud_savegame.config_utils import get_list as get_list
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -116,54 +119,6 @@ def get_hostname() -> str:
     This is used to tag commits and identify the source of backups in the git history.
     """
     return socket.gethostname()
-
-
-def get_str(config: ConfigParser, section: str, key: str) -> Optional[str]:
-    """
-    Retrieve a string value from the configuration.
-
-    Returns:
-        The value if the section and key exist, otherwise None.
-    """
-    if section not in config or key not in config[section]:
-        return None
-    return config[section][key]
-
-
-def get_list(config: ConfigParser, section: str, key: str) -> Optional[List[str]]:
-    """
-    Retrieve a list of strings from the configuration.
-
-    The value is split using the delimiter defined in `general.divider` (defaulting to comma).
-    """
-    divider = get_str(config, "general", "divider") or ","
-    raw = get_str(config, section, key) or ""
-    raw = raw.strip()
-    if not raw:
-        return None
-    return list(raw.split(divider))
-
-
-def get_paths(config: ConfigParser, section: str, key: str) -> Set[Path]:
-    """
-    Retrieve a set of Path objects from the configuration.
-
-    It expands user paths (e.g., `~`) and resolves them to absolute paths.
-    """
-    ret = []
-    for p in get_list(config, section, key) or []:
-        ret.append(Path(os.path.expanduser(p)).resolve())
-    return set(ret)
-
-
-def get_bool(config: ConfigParser, section: str, key: str) -> bool:
-    """
-    Check if a key exists in the configuration section.
-
-    This treats the presence of the key as True, and absence as False.
-    The actual value of the key is ignored.
-    """
-    return get_str(config, section, key) is not None
 
 
 def is_path_ignored(path: Path, ignored_paths: Set[Path]) -> bool:

--- a/cloud_savegame/config_utils.py
+++ b/cloud_savegame/config_utils.py
@@ -1,0 +1,52 @@
+import os
+from configparser import ConfigParser
+from pathlib import Path
+from typing import List, Optional, Set
+
+
+def get_str(config: ConfigParser, section: str, key: str) -> Optional[str]:
+    """
+    Retrieve a string value from the configuration.
+
+    Returns:
+        The value if the section and key exist, otherwise None.
+    """
+    if section not in config or key not in config[section]:
+        return None
+    return config[section][key]
+
+
+def get_list(config: ConfigParser, section: str, key: str) -> Optional[List[str]]:
+    """
+    Retrieve a list of strings from the configuration.
+
+    The value is split using the delimiter defined in `general.divider` (defaulting to comma).
+    """
+    divider = get_str(config, "general", "divider") or ","
+    raw = get_str(config, section, key) or ""
+    raw = raw.strip()
+    if not raw:
+        return None
+    return list(raw.split(divider))
+
+
+def get_paths(config: ConfigParser, section: str, key: str) -> Set[Path]:
+    """
+    Retrieve a set of Path objects from the configuration.
+
+    It expands user paths (e.g., `~`) and resolves them to absolute paths.
+    """
+    ret = []
+    for p in get_list(config, section, key) or []:
+        ret.append(Path(os.path.expanduser(p)).resolve())
+    return set(ret)
+
+
+def get_bool(config: ConfigParser, section: str, key: str) -> bool:
+    """
+    Check if a key exists in the configuration section.
+
+    This treats the presence of the key as True, and absence as False.
+    The actual value of the key is ignored.
+    """
+    return get_str(config, section, key) is not None

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -1,0 +1,51 @@
+import unittest
+from configparser import ConfigParser
+from pathlib import Path
+
+from cloud_savegame.config_utils import get_bool, get_list, get_paths, get_str
+
+
+class TestConfigUtils(unittest.TestCase):
+    def setUp(self):
+        self.config = ConfigParser()
+        self.config["section"] = {
+            "key_str": "value",
+            "key_list": "item1,item2",
+            "key_list_space": "item1, item2",
+            "key_bool_present": "anything",
+            "key_path": "/tmp/path1,/tmp/path2",
+        }
+        self.config["general"] = {"divider": ","}
+
+    def test_get_str(self):
+        self.assertEqual(get_str(self.config, "section", "key_str"), "value")
+        self.assertIsNone(get_str(self.config, "section", "missing"))
+        self.assertIsNone(get_str(self.config, "missing", "key_str"))
+
+    def test_get_list(self):
+        self.assertEqual(get_list(self.config, "section", "key_list"), ["item1", "item2"])
+        # Note: get_list does not strip individual items, only the raw string.
+        self.assertEqual(get_list(self.config, "section", "key_list_space"), ["item1", " item2"])
+        self.assertIsNone(get_list(self.config, "section", "missing"))
+
+    def test_get_bool(self):
+        self.assertTrue(get_bool(self.config, "section", "key_bool_present"))
+        self.assertFalse(get_bool(self.config, "section", "missing"))
+
+    def test_get_paths(self):
+        # We need to be careful with paths as they are resolved.
+        # Just checking if it returns a set of Paths
+        paths = get_paths(self.config, "section", "key_path")
+        self.assertIsInstance(paths, set)
+        self.assertEqual(len(paths), 2)
+        self.assertTrue(all(isinstance(p, Path) for p in paths))
+
+        # Test expanduser
+        self.config["section"]["home_path"] = "~/test"
+        paths = get_paths(self.config, "section", "home_path")
+        self.assertEqual(len(paths), 1)
+
+    def test_get_list_custom_divider(self):
+        self.config["general"]["divider"] = ";"
+        self.config["section"]["key_list_semicolon"] = "item1;item2"
+        self.assertEqual(get_list(self.config, "section", "key_list_semicolon"), ["item1", "item2"])


### PR DESCRIPTION
Extracted configuration helper functions (`get_str`, `get_list`, `get_paths`, `get_bool`) from `cloud_savegame/__init__.py` to a new module `cloud_savegame/config_utils.py`.

**Rationale:**
- **Separation of Concerns:** Moves configuration parsing logic out of the main application module.
- **Improved Testability:** Allows unit testing of config helpers in isolation (added `tests/test_config_utils.py`).
- **Reduction of Complexity:** Reduces the line count and responsibilities of `cloud_savegame/__init__.py`.

**Changes:**
- Created `cloud_savegame/config_utils.py`.
- Updated `cloud_savegame/__init__.py` to import these helpers.
- Added unit tests.

**Justification:**
Follows Martin Fowler's "Extract Method" and "Extract Class/Module" refactoring patterns to improve cohesion and reduce coupling.


---
*PR created automatically by Jules for task [10407129155502035402](https://jules.google.com/task/10407129155502035402) started by @lucasew*